### PR TITLE
Create EndpointProcess Model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,9 +51,11 @@ gem "bootsnap", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
-  gem 'rspec-rails', '~> 6.0.0'
+  gem "rspec-rails", "~> 6.0.0"
+  gem 'shoulda-matchers', '~> 5.0'
   gem "factory_bot_rails"
   gem "faker"
+  gem "annotate"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     bindex (0.8.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
@@ -192,6 +195,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (5.2.0)
+      activesupport (>= 5.2.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -231,6 +236,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   capybara
   debug
@@ -242,6 +248,7 @@ DEPENDENCIES
   rails (~> 7.0.4)
   rspec-rails (~> 6.0.0)
   selenium-webdriver
+  shoulda-matchers (~> 5.0)
   sprockets-rails
   sqlite3 (~> 1.4)
   stimulus-rails

--- a/app/models/endpoint_process.rb
+++ b/app/models/endpoint_process.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: endpoint_processes
+#
+#  id         :integer          not null, primary key
+#  command    :text
+#  name       :string
+#  start_time :datetime
+#  user_name  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  process_id :integer
+#
+class EndpointProcess < ApplicationRecord
+  validates_presence_of :command
+
+  after_validation :execute_process, on: :create
+
+  private
+
+  def execute_process
+    # exit early if command is not present
+    return false if command.blank?
+
+    response = RedCanary::ExecuteProcess.new(command).call
+
+    self.name = response[:name]
+    self.process_id = response[:process_id]
+    self.start_time = response[:start_time]
+    self.user_name = response[:user_name]
+  end
+end

--- a/app/services/red_canary/execute_process.rb
+++ b/app/services/red_canary/execute_process.rb
@@ -15,7 +15,11 @@ module RedCanary
 
     def execute_command(command)
       # Executes the command on the host system
-      pid = Process.spawn(command)
+      pid = Process.spawn(command) rescue nil
+
+      # Return early if the process could not be spawned
+      return {} unless pid
+
       process_name = command.split(' ').first
       process_detail_command = "ps -p #{pid} -wo lstart"
       process_start_time = DateTime.parse(`#{process_detail_command}`.split("\n").last)

--- a/db/migrate/20221104165435_create_endpoint_processes.rb
+++ b/db/migrate/20221104165435_create_endpoint_processes.rb
@@ -1,0 +1,13 @@
+class CreateEndpointProcesses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :endpoint_processes do |t|
+      t.text :command
+      t.string :name
+      t.integer :process_id
+      t.datetime :start_time
+      t.string :user_name
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/endpoint_processes.rb
+++ b/spec/factories/endpoint_processes.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: endpoint_processes
+#
+#  id         :integer          not null, primary key
+#  command    :text
+#  name       :string
+#  start_time :datetime
+#  user_name  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  process_id :integer
+#
+FactoryBot.define do
+  factory :endpoint_process do
+    command { "MyText" }
+    name { "MyString" }
+    process_id { "MyString" }
+    start_time { "2022-11-04 09:54:35" }
+    user_name { "MyString" }
+  end
+end

--- a/spec/models/endpoint_process_spec.rb
+++ b/spec/models/endpoint_process_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: endpoint_processes
+#
+#  id         :integer          not null, primary key
+#  command    :text
+#  name       :string
+#  start_time :datetime
+#  user_name  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  process_id :integer
+#
+require 'rails_helper'
+
+RSpec.describe EndpointProcess, type: :model do
+  it { should validate_presence_of(:command) }
+
+  describe 'on create' do
+    let(:command) { 'cat /proc/cpuinfo' }
+    let(:process) { described_class.create(command: command) }
+
+    it 'executes the command' do
+      process.reload
+      expect(process.name).to eq('cat')
+      expect(process.process_id).to be_a(Integer)
+      expect(process.start_time.present?).to be(true)
+      expect(process.user_name).to eq(ENV['USER'])
+    end
+
+    it 'creates an empty record if the command is not valid' do
+      process = described_class.create(command: 'invalid command')
+      expect(process.command).to eq('invalid command')
+      expect(process.persisted?).to be(true)
+      expect(process.name).to be_nil
+      expect(process.process_id).to be_nil
+      expect(process.start_time).to be_nil
+      expect(process.user_name).to be_nil
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,12 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Include FactoryBot syntax to simplify calls to factories
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end

--- a/spec/services/red_canary/execute_process_spec.rb
+++ b/spec/services/red_canary/execute_process_spec.rb
@@ -15,5 +15,11 @@ RSpec.describe RedCanary::ExecuteProcess do
       expect(response[:start_time]).to be_a(DateTime)
       expect(response[:user_name]).to eq(ENV['USER'])
     end
+
+    it 'returns an empty hash if the command is not valid' do
+      service = described_class.new('invalid command')
+      response = service.call
+      expect(response).to eq({})
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  require 'shoulda/matchers'
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
This PR creates a model and tests to record Endpoint Processes run through the `RedCanary::ExecuteProcess` service.

New Processes can now be recorded with the command:
```
EndpointProcess.create(command: 'cat /proc/cpuinfo')
```

The 'annotate' gem was also added in this PR to auto-comment models. 