### PR TITLE
Create Service and Model to Log Network Activity

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 end

--- a/app/models/endpoint_process.rb
+++ b/app/models/endpoint_process.rb
@@ -17,6 +17,7 @@ class EndpointProcess < ApplicationRecord
   validates_presence_of :command
 
   has_one :file_activity, dependent: :destroy
+  has_one :network_activity, dependent: :destroy
 
   after_validation :execute_process, on: :create
 

--- a/app/models/network_activity.rb
+++ b/app/models/network_activity.rb
@@ -1,0 +1,66 @@
+# == Schema Information
+#
+# Table name: network_activities
+#
+#  id                  :integer          not null, primary key
+#  data                :text
+#  data_protocol       :string
+#  data_size           :integer
+#  destination_address :string
+#  destination_port    :integer
+#  source_address      :string
+#  source_port         :integer
+#  url                 :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  endpoint_process_id :integer          not null
+#
+# Indexes
+#
+#  index_network_activities_on_endpoint_process_id  (endpoint_process_id)
+#
+# Foreign Keys
+#
+#  endpoint_process_id  (endpoint_process_id => endpoint_processes.id)
+#
+class NetworkActivity < ApplicationRecord
+  belongs_to :endpoint_process
+
+  validates_presence_of :destination_address,
+                        :destination_port,
+                        :data_size,
+                        :data_protocol,
+                        :source_address,
+                        :source_port,
+                        :url
+
+  before_validation :parse_url
+  before_validation :calculate_data_size
+  before_validation :initiate_network_connection
+
+  private
+
+  def calculate_data_size
+    self.data_size = data.to_json.length
+  end
+
+  def initiate_network_connection
+    return false if url.blank?
+
+    response = RedCanary::NetworkActivity.new(url, data).call
+
+    self.endpoint_process = response
+  end
+
+  def parse_url
+    parsed_url = URI.parse(url)
+
+    self.destination_address = parsed_url.host
+    self.destination_port = parsed_url.port
+    self.data_protocol = parsed_url.scheme
+    self.source_address = Socket.ip_address_list.detect(&:ipv4_private?).ip_address
+    self.source_port = 0
+  rescue URI::InvalidURIError
+    return ArgumentError, "Invalid URL: #{url}"
+  end
+end

--- a/app/models/network_activity.rb
+++ b/app/models/network_activity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: network_activities

--- a/app/services/red_canary/network_activity.rb
+++ b/app/services/red_canary/network_activity.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RedCanary
+  # NetworkActivity accepts a URL {String} and data {JSON} param, then uses a curl command to
+  # initiate a network connection.
+  class NetworkActivity
+    def initialize(url, data = {})
+      return if url.blank?
+
+      @url = url
+      @data = data.to_json
+    end
+
+    def call
+      initiate_network_connection(@url, @data)
+    end
+
+    private
+
+    def initiate_network_connection(url, data)
+      command = "curl -X POST -H \"Content-Type: application/json\" -d '#{data}' -o /dev/null #{url}"
+      EndpointProcess.create(command: command)
+    end
+  end
+end

--- a/db/migrate/20221104203008_create_network_activities.rb
+++ b/db/migrate/20221104203008_create_network_activities.rb
@@ -1,0 +1,17 @@
+class CreateNetworkActivities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :network_activities do |t|
+      t.text :data
+      t.string :data_protocol
+      t.integer :data_size
+      t.string :destination_address
+      t.integer :destination_port
+      t.belongs_to :endpoint_process, null: false, foreign_key: true
+      t.string :url, null: false
+      t.string :source_address
+      t.integer :source_port
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_04_191653) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_04_203008) do
   create_table "endpoint_processes", force: :cascade do |t|
     t.text "command"
     t.string "name"
@@ -30,5 +30,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_04_191653) do
     t.index ["endpoint_process_id"], name: "index_file_activities_on_endpoint_process_id"
   end
 
+  create_table "network_activities", force: :cascade do |t|
+    t.text "data"
+    t.string "data_protocol"
+    t.integer "data_size"
+    t.string "destination_address"
+    t.integer "destination_port"
+    t.integer "endpoint_process_id", null: false
+    t.string "url", null: false
+    t.string "source_address"
+    t.integer "source_port"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["endpoint_process_id"], name: "index_network_activities_on_endpoint_process_id"
+  end
+
   add_foreign_key "file_activities", "endpoint_processes"
+  add_foreign_key "network_activities", "endpoint_processes"
 end

--- a/spec/factories/endpoint_processes.rb
+++ b/spec/factories/endpoint_processes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: endpoint_processes

--- a/spec/factories/file_activities.rb
+++ b/spec/factories/file_activities.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: file_activities

--- a/spec/factories/network_activities.rb
+++ b/spec/factories/network_activities.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: network_activities
+#
+#  id                  :integer          not null, primary key
+#  data                :text
+#  data_protocol       :string
+#  data_size           :integer
+#  destination_address :string
+#  destination_port    :integer
+#  source_address      :string
+#  source_port         :integer
+#  url                 :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  endpoint_process_id :integer          not null
+#
+# Indexes
+#
+#  index_network_activities_on_endpoint_process_id  (endpoint_process_id)
+#
+# Foreign Keys
+#
+#  endpoint_process_id  (endpoint_process_id => endpoint_processes.id)
+#
+FactoryBot.define do
+  factory :network_activity do
+    url { 'https://fake-domain.redcanary.com' }
+    data { { foo: 'bar' } }
+  end
+end

--- a/spec/factories/network_activities.rb
+++ b/spec/factories/network_activities.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: network_activities

--- a/spec/models/network_activity_spec.rb
+++ b/spec/models/network_activity_spec.rb
@@ -1,0 +1,57 @@
+# == Schema Information
+#
+# Table name: network_activities
+#
+#  id                  :integer          not null, primary key
+#  data                :text
+#  data_protocol       :string
+#  data_size           :integer
+#  destination_address :string
+#  destination_port    :integer
+#  source_address      :string
+#  source_port         :integer
+#  url                 :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  endpoint_process_id :integer          not null
+#
+# Indexes
+#
+#  index_network_activities_on_endpoint_process_id  (endpoint_process_id)
+#
+# Foreign Keys
+#
+#  endpoint_process_id  (endpoint_process_id => endpoint_processes.id)
+#
+require 'rails_helper'
+
+RSpec.describe NetworkActivity, type: :model do
+  describe '#call' do
+    let!(:network_activity) { create(:network_activity) }
+
+    describe 'validations' do
+      it { should validate_presence_of(:url) }
+    end
+
+    describe 'associations' do
+      it { should belong_to(:endpoint_process) }
+    end
+
+    describe 'private methods' do
+      describe '#perform_network_activity' do
+        it 'creates a new endpoint process' do
+          expect(network_activity.persisted?).to be(true)
+          expect(network_activity.url).to eq('https://fake-domain.redcanary.com')
+          expect(network_activity.data.to_s).to eq({ foo: 'bar' }.to_s)
+          expect(network_activity.endpoint_process.persisted?).to be(true)
+          expect(network_activity.endpoint_process.name).to eq("curl")
+        end
+
+        it 'returns false if url is blank' do
+          network_activity = described_class.create(url: '')
+          expect(network_activity.persisted?).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/network_activity_spec.rb
+++ b/spec/models/network_activity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: network_activities

--- a/spec/services/red_canary/export_log_spec.rb
+++ b/spec/services/red_canary/export_log_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe RedCanary::ExportLog do
     context 'when there is log data' do
       let!(:endpoint_process) { create(:endpoint_process) }
       let!(:file_activity) { create(:file_activity) }
+      let!(:network_activity) { create(:network_activity) }
 
       it 'returns a JSON string of the log data' do
         expect(service.call).to eq(EndpointProcess.all.to_json)
@@ -27,6 +28,7 @@ RSpec.describe RedCanary::ExportLog do
         expect(parsed_csv[0]).to eq(EndpointProcess.first.attributes.keys)
         expect(parsed_csv[1]).to eq(EndpointProcess.first.attributes.values.map{|val| val.to_s})
         expect(parsed_csv[2]).to eq(EndpointProcess.second.attributes.values.map{|val| val.to_s})
+        expect(parsed_csv[3]).to eq(EndpointProcess.third.attributes.values.map{|val| val.to_s})
       end
     end
   end


### PR DESCRIPTION
This PR adds a Model and Service class, similar to FileActivity, to handle network activity.

The Services sends a `curl` command to the EndpointProcess model to post data to a URL.