### PR TITLE
Expanded logging to include File and Network activity attributes

### DIFF
--- a/app/models/file_activity.rb
+++ b/app/models/file_activity.rb
@@ -36,7 +36,7 @@ class FileActivity < ApplicationRecord
   def perform_file_activity
     return false if file_path.blank? || activity.blank?
 
-    response = RedCanary::FileActivity.new(file_path, activity).call
+    response = RedCanary::ExecuteFileActivity.new(file_path, activity).call
 
     self.endpoint_process = response
   end

--- a/app/models/network_activity.rb
+++ b/app/models/network_activity.rb
@@ -49,7 +49,7 @@ class NetworkActivity < ApplicationRecord
   def initiate_network_connection
     return false if url.blank?
 
-    response = RedCanary::NetworkActivity.new(url, data).call
+    response = RedCanary::ExecuteNetworkActivity.new(url, data).call
 
     self.endpoint_process = response
   end

--- a/app/services/red_canary/execute_file_activity.rb
+++ b/app/services/red_canary/execute_file_activity.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module RedCanary
-  # FileActivity accepts a file path {String} and an action {Symbol} [:create, :update, :destroy] and
+  # ExecuteFileActivity accepts a file path {String} and an action {Symbol} [:create, :update, :destroy] and
   # returns an EndpointProcess on success.
-  class FileActivity
+  class ExecuteFileActivity
     def initialize(file_path, action)
       return if file_path.blank? || action.blank?
 

--- a/app/services/red_canary/execute_network_activity.rb
+++ b/app/services/red_canary/execute_network_activity.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module RedCanary
-  # NetworkActivity accepts a URL {String} and data {JSON} param, then uses a curl command to
+  # ExecuteNetworkActivity accepts a URL {String} and data {JSON} param, then uses a curl command to
   # initiate a network connection.
-  class NetworkActivity
+  class ExecuteNetworkActivity
     def initialize(url, data = {})
       return if url.blank?
 
@@ -18,7 +18,8 @@ module RedCanary
     private
 
     def initiate_network_connection(url, data)
-      command = "curl -X POST -H \"Content-Type: application/json\" -d '#{data}' -o /dev/null #{url}"
+      data_string = data.empty? ? '' : "-d '#{data}'"
+      command = "curl -X POST -H \"Content-Type: application/json\" #{data_string} -o /dev/null #{url}"
       EndpointProcess.create(command: command)
     end
   end

--- a/app/services/red_canary/export_log.rb
+++ b/app/services/red_canary/export_log.rb
@@ -17,10 +17,14 @@ module RedCanary
       export_log(@format, @start_date, @end_date)
     end
 
+    def csv_headers
+      EndpointProcess.attribute_names + FileActivity.attribute_names + NetworkActivity.attribute_names
+    end
+
     private
 
     def export_log(format, start_date, end_date)
-      log_data = EndpointProcess.started_between(start_date, end_date)
+      log_data = EndpointProcess.started_between(start_date, end_date).includes(:file_activity, :network_activity)
 
       # Return early if there is no log data
       return '' if log_data.empty?
@@ -32,17 +36,27 @@ module RedCanary
     def format_log_data(format, log_data)
       case format
       when :json
-        log_data.to_json
+        generate_json(log_data)
       when :csv
-        CSV.generate do |csv|
-          csv << log_data.first.attributes.keys
-          log_data.each do |process|
-            csv << process.attributes.values
-          end
-        end
+        generate_csv(log_data)
       else
-        log_data.to_json
+        generate_json(log_data)
       end
+    end
+
+    def generate_csv(log_data)
+      CSV.generate do |csv|
+        csv << csv_headers
+        log_data.each do |process|
+          csv << process.attributes.values +
+            (process.file_activity.present? ? process.file_activity.attributes.values : []) +
+            (process.network_activity.present? ? process.network_activity.attributes.values : [])
+        end
+      end
+    end
+
+    def generate_json(log_data)
+      log_data.to_json(include: [:file_activity, :network_activity])
     end
   end
 end

--- a/spec/models/network_activity_spec.rb
+++ b/spec/models/network_activity_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe NetworkActivity, type: :model do
           expect(network_activity.persisted?).to be(true)
           expect(network_activity.url).to eq('https://fake-domain.redcanary.com')
           expect(network_activity.data.to_s).to eq({ foo: 'bar' }.to_s)
+          expect(network_activity.data_protocol).to eq('https')
+          expect(network_activity.destination_address).to eq('fake-domain.redcanary.com')
           expect(network_activity.endpoint_process.persisted?).to be(true)
           expect(network_activity.endpoint_process.name).to eq("curl")
         end

--- a/spec/services/red_canary/execute_file_activity_spec.rb
+++ b/spec/services/red_canary/execute_file_activity_spec.rb
@@ -2,10 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe RedCanary::FileActivity do
+RSpec.describe RedCanary::ExecuteFileActivity do
   let(:file_path) { 'test_file.txt' }
 
-  subject { RedCanary::FileActivity.new(file_path, action) }
+  subject { RedCanary::ExecuteFileActivity.new(file_path, action) }
 
   before do
     File.delete(file_path) if File.exist?(file_path)

--- a/spec/services/red_canary/execute_network_activity_spec.rb
+++ b/spec/services/red_canary/execute_network_activity_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RedCanary::ExecuteNetworkActivity do
+  subject { RedCanary::ExecuteNetworkActivity.new('https://fake-domain.redcanary.com', {foo: 'bar'}) }
+
+  describe '#call' do
+    it 'creates a new network activity' do
+      response = subject.call
+      expect(response).to be_a(EndpointProcess)
+      expect(response.name).to eq('curl')
+    end
+  end
+end

--- a/spec/services/red_canary/export_log_spec.rb
+++ b/spec/services/red_canary/export_log_spec.rb
@@ -18,17 +18,21 @@ RSpec.describe RedCanary::ExportLog do
       let!(:network_activity) { create(:network_activity) }
 
       it 'returns a JSON string of the log data' do
-        expect(service.call).to eq(EndpointProcess.all.to_json)
+        expect(service.call).to eq(EndpointProcess.all.to_json(include: [:file_activity, :network_activity]))
       end
 
       it 'returns a CSV string of the log data' do
         response = RedCanary::ExportLog.new(format: :csv).call
         parsed_csv = CSV.parse(response)
 
-        expect(parsed_csv[0]).to eq(EndpointProcess.first.attributes.keys)
+        expect(parsed_csv[0]).to eq(RedCanary::ExportLog.new.csv_headers)
         expect(parsed_csv[1]).to eq(EndpointProcess.first.attributes.values.map{|val| val.to_s})
-        expect(parsed_csv[2]).to eq(EndpointProcess.second.attributes.values.map{|val| val.to_s})
-        expect(parsed_csv[3]).to eq(EndpointProcess.third.attributes.values.map{|val| val.to_s})
+        file_process = EndpointProcess.second
+        expect(parsed_csv[2]).to eq(file_process.attributes.values.map{|val| val.to_s} +
+                                      file_process.file_activity.attributes.values.map{|val| val.to_s})
+        network_process = EndpointProcess.third
+        expect(parsed_csv[3]).to eq(network_process.attributes.values.map{|val| val.to_s} +
+                                      network_process.network_activity.attributes.values.map{|val| val.to_s})
       end
     end
   end


### PR DESCRIPTION
This PR adds support for `FileActivity` and `NetworkActivity` attributes, outside the core `EndpointProcess` attributes.

This PR also renames `RedCanary::` Services to to follow a more readable standard and respect naming convention scopes.